### PR TITLE
Add an ability to choose API version for docker client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Hot To Run
+# How To Run
 docker run -it --rm \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	-v /myconfiglocation/secrets.json:/ddns/secrets.json \
@@ -55,6 +55,19 @@ zone "myddnszone.mydomain.xtld" IN {
         file "dynamic/myddnszone.mydomain.xtld.zone";
         allow-update { key "my.key.file"; };
 };
+```
+
+## Allowed arguments
+This container uses pretty new docker client with newest API support. If your
+server uses older API version and refuses to speak with client, you can pass
+an option **-v** or **--apiversion** with needed version number. Example:
+
+```
+$ docker run -it --rm \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	-v /myconfiglocation/secrets.json:/ddns/secrets.json \
+	-v /myconfiglocation/docker-ddns.json:/ddns/docker-ddns.json \
+	 mbartsch/docker-ddns -v 1.24
 ```
 
 

--- a/docker-ddns.py
+++ b/docker-ddns.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import logging
 import docker
 import json
@@ -15,7 +16,12 @@ logging.basicConfig( format = '%(asctime)s:%(levelname)s:%(message)s', level = l
 configfile = 'docker-ddns.json'
 tsigfile = 'secrets.json'
 
-client = docker.from_env()
+parser = argparse.ArgumentParser(description="Dynamic DNS updater")
+parser.add_argument("-v", "--apiversion", default=None, help="Docker api version")
+args = parser.parse_args()
+if args.apiversion: client = docker.from_env(version=args.apiversion)
+else: client = docker.from_env()
+
 """
 LoadConfig
   Load the configuration options from configfile and tsigfile


### PR DESCRIPTION
In some cases, default client API version and docker API version
differ from each other. In such case server will refuse to work
with newer client version. To be able to fix such situation, add
an option to manually pass API version to client.